### PR TITLE
Issue #21 | airdropAccount should support standalone

### DIFF
--- a/soroban-react-dapp/contracts/utils/contract.ts
+++ b/soroban-react-dapp/contracts/utils/contract.ts
@@ -218,7 +218,7 @@ export async function bumpContractCode(wasmKey: string, addressBook: AddressBook
 export async function airdropAccount(user: Keypair, network?: string) {
   // Define configuration for the network
   var networkConfig;
-  if (typeof network !== undefined && network === 'standalone') {
+  if (network !== undefined) {
     networkConfig = config(network);
   } else {
     networkConfig = config('testnet');

--- a/soroban-react-dapp/contracts/utils/contract.ts
+++ b/soroban-react-dapp/contracts/utils/contract.ts
@@ -215,10 +215,18 @@ export async function bumpContractCode(wasmKey: string, addressBook: AddressBook
   console.log(result.status, '\n');
 }
 
-export async function airdropAccount(user: Keypair) {
+export async function airdropAccount(user: Keypair, network?: string) {
+  // Define configuration for the network
+  var networkConfig;
+  if (typeof network !== undefined && network === 'standalone') {
+    networkConfig = config(network);
+  } else {
+    networkConfig = config('testnet');
+  }
+
   try {
     console.log('Start funding');
-    await loadedConfig.rpc.requestAirdrop(user.publicKey(), loadedConfig.friendbot);
+    await networkConfig.rpc.requestAirdrop(user.publicKey(), networkConfig.friendbot);
     console.log('Funded: ', user.publicKey());
   } catch (e) {
     console.log(user.publicKey(), ' already funded');

--- a/soroban-react-dapp/contracts/utils/contract.ts
+++ b/soroban-react-dapp/contracts/utils/contract.ts
@@ -218,7 +218,7 @@ export async function bumpContractCode(wasmKey: string, addressBook: AddressBook
 export async function airdropAccount(user: Keypair, network?: string) {
   // Define configuration for the network
   var networkConfig;
-  if (network !== undefined) {
+  if (network !== undefined && (network === 'standalone' || network === 'futurenet')) {
     networkConfig = config(network);
   } else {
     networkConfig = config('testnet');


### PR DESCRIPTION
Solves Issue #21 

- Added a new parameter called `network`, which is optional to the function `airdropAccount`
- Created the proper validation, if `network === standalone` use that configuration otherwise use `testnet`
- Modified await call since variable name changed.