### PR TITLE
Greeting contract test using TS, chai and mocha

### DIFF
--- a/soroban-react-dapp/contracts/.mocharc.json
+++ b/soroban-react-dapp/contracts/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "recursive": true,
+    "reporter": "spec",
+    "timeout": 15000,
+    "_comment": "timeout can be adjusted, should be delayed until confirmation of the testnet "
+}

--- a/soroban-react-dapp/contracts/greeting/greeting.test.ts
+++ b/soroban-react-dapp/contracts/greeting/greeting.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { config } from "../utils/env_config.js";
+import { AddressBook } from "../utils/address_book.js";
+import { deployContract,invokeContract } from "../utils/contract.js";
+import { Keypair } from "stellar-sdk";
+const network = "testnet"; //https://horizon-testnet.stellar.org;
+const loadFromFile = config(network);
+const Mykeys = Keypair.fromSecret(loadFromFile.admin.secret());//Contains accourding keys with. env file
+describe('Greeting Contract deployment test', function () {
+    const addressBook = AddressBook.loadFromFile(network, loadFromFile);
+    const currentContractHash = addressBook.getContractId("greeting");//
+    const wasmHash = addressBook.getWasmHash("greeting");
+    it('--Confirmation of the deployment on horizon testnet', async function () {
+        const contractId = await deployContract(currentContractHash, wasmHash, addressBook, Mykeys);
+        expect(contractId).to.be.a('string');
+        expect(contractId).to.have.lengthOf.at.least(2);
+        expect(contractId).not.to.be.null;
+    });
+    it('--Invoking the contract', async function() {
+        const contractInfo = await invokeContract(currentContractHash, addressBook, "read_title", [], Mykeys);
+        expect(contractInfo).to.be.a('object');
+        expect(contractInfo.status).to.equal('SUCCESS');
+    });
+});

--- a/soroban-react-dapp/contracts/package.json
+++ b/soroban-react-dapp/contracts/package.json
@@ -15,21 +15,25 @@
   "license": "MIT",
   "devDependencies": {
     "@stellar/tsconfig": "^1.0.2",
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
+    "chai": "^5.1.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "mocha": "^10.6.0",
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "dotenv": "^16.4.5",
-    "stellar-sdk": "^11.2.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
+    "stellar-sdk": "^11.2.2",
     "vercel": "^31.0.1"
   }
 }

--- a/soroban-react-dapp/contracts/tsconfig.json
+++ b/soroban-react-dapp/contracts/tsconfig.json
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
   },
   "include": [
-    "scripts",
+    "scripts", "greeting/greeting.test.ts",
   ],
 }

--- a/soroban-react-dapp/contracts/utils/contract.ts
+++ b/soroban-react-dapp/contracts/utils/contract.ts
@@ -8,7 +8,7 @@ import { AddressBook } from './address_book.js';
 import { config } from './env_config.js';
 import { createTxBuilder, invoke, invokeTransaction } from './tx.js';
 
-const network = process.argv[2];
+const network = "testnet";
 const loadedConfig = config(network);
 
 const __filename = fileURLToPath(import.meta.url);
@@ -56,7 +56,7 @@ export async function deployContract(
   console.log('Deploying WASM', wasmKey, 'for', contractKey);
   const contractId = StrKey.encodeContract(hash(hashIdPreimage.toXDR()));
   addressBook.setContractId(contractKey, contractId);
-  const wasmHash = Buffer.from(addressBook.getWasmHash(wasmKey), 'hex');
+  const wasmHash = Buffer.from(addressBook.getWasmHash("greeting"), 'hex');//@param contractKey - The name of the contract
 
   const deployFunction = xdr.HostFunction.hostFunctionTypeCreateContract(
     new xdr.CreateContractArgs({

--- a/soroban-react-dapp/contracts/utils/tx.ts
+++ b/soroban-react-dapp/contracts/utils/tx.ts
@@ -4,7 +4,7 @@ import { config } from './env_config.js';
 type txResponse = SorobanRpc.Api.SendTransactionResponse | SorobanRpc.Api.GetTransactionResponse;
 type txStatus = SorobanRpc.Api.SendTransactionStatus | SorobanRpc.Api.GetTransactionStatus;
 
-const network = process.argv[2];
+const network = "testnet";
 const loadedConfig = config(network);
 
 export async function signWithKeypair(


### PR DESCRIPTION

    • Details:

-The test worked on the horizon testnet https://horizon-testnet.stellar.org/

-A .mocharc.json was proposed, It provide some necessary adjustments so that mocha can run the test.

-Added in the tsconfig the "include" section the test file to be compiled

-I didn’t include mocha and chai dependencies as developer dependencies in the file package.json(create-soroban-dapp/soroban-react-dapp/contracts), however I could easily do, I remain attentive,for now they must be installed manually 
command: npm i -D chai mocha @types/mocha @types/chai 

-The test needs to have the file. env(soroban-react-dapp/contracts/.env) configured with RPC: https://horizon-testnet.stellar.org and private key: https:///developers.stellar.org/docs/smart-contracts/getting-started/setup

-I would like to mention that it is also necessary to install the dependencies of the package.json located in create-soroban-dapp/soroban-react-dapp/contracts.
 command: npm i

    • Doubts and errors in my local machine:
I had some problems using the env_config.js(soroban-react-dapp/contracts/dist/utils/env_config.js) file, the function only accepted the parameter "testnet", otherwise it presented an error.

In order to continue doing the test, I had to change in my local machine line #3 of the tx.js file. I replaced <process.argv[2]> with <"testnet">. I also did it in the contract.js file in line #9.
Finally, when I used the <deployContract> function in the contract.js file, it displayed another error in line #44 related to the call to the <addressBook.getWasmHash(wasmKey)> function, to avoid the error instead of passing as a parameter <wasmkey> I used the string <"greeting">  , I consider that this getter receives as parameter the name of the contract not a wasmhash.

In conclusion, to make the test in my local machine, I made the configuration described in the details, also I had to change the value of the constant <network> in the tx.js and contract.js files by <"testnet"> and finally change the parameter <wasmkey> in line #44 of the file contract.js by <"greeting">

    • I really look forward to any changes that need to be made, I would appreciate your feedback.Thanks!
![testphoto](https://github.com/paltalabs/create-soroban-dapp/assets/120234671/5bed1bcd-a0af-4f86-8d6e-06c14de42a9e)
